### PR TITLE
Backfill missing lab metadata (3 files)

### DIFF
--- a/Instructions/Labs/01-exercise-template.md
+++ b/Instructions/Labs/01-exercise-template.md
@@ -1,8 +1,14 @@
 ---
 lab:
-    title: 'Exercise Title'
-    module: 'Learn module title'
+  title: Exercise Title
+  module: Learn module title
+  description: In this exercise you will <!-- provide a description of what they'll
+    do and why it;s important -->
+  duration: 72 minutes
+  level: 100
+  islab: true
 ---
+
 <!--
 Edit the metadata above to manage the list of exercises in the home page of the GitHub site that gets generated.
 You can delete the module and edit index.md in the root of the repo to customize the display so that only the exercises are listed

--- a/Instructions/Labs/LAB_01_deploying_arm_templates.md
+++ b/Instructions/Labs/LAB_01_deploying_arm_templates.md
@@ -1,7 +1,20 @@
 ---
 lab:
-    title: 'Lab: Deploying Azure Resource Manager templates'
-    module: 'Module 1: Exploring Azure Resource Manager'
+  title: 'Lab: Deploying Azure Resource Manager templates'
+  module: 'Module 1: Exploring Azure Resource Manager'
+  description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
+    lobortis, erat vel egestas faucibus, dui magna semper velit, id congue sapien
+    lectus id turpis. Nam egestas tempus enim. Ut venenatis vehicula ex, id rutrum
+    odio lacinia at. Donec congue, tortor sed fermentum imperdiet, mauris mi auctor
+    dui, ac cursus ex augue a odio. Aliquam erat volutpat. Vivamus faucibus fringilla
+    augue in dignissim. Quisque sit amet nulla id risus gravida auctor. Ut in est
+    varius, cursus odio rhoncus, placerat erat. Suspendisse nec metus est.
+  duration: 5 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Resource Manager
 ---
 
 # Lab: Deploying Azure Resource Manager templates

--- a/Instructions/Labs/LAB_AK_01_deploying_arm_templates.md
+++ b/Instructions/Labs/LAB_AK_01_deploying_arm_templates.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Lab: Deploying Azure Resource Manager templates'
-    type: 'Answer Key'
-    module: 'Module 1: Exploring Azure Resource Manager'
+  title: 'Lab: Deploying Azure Resource Manager templates'
+  type: Answer Key
+  module: 'Module 1: Exploring Azure Resource Manager'
+  description: Maecenas fringilla ac purus non tincidunt. Aenean pellentesque velit
+    id suscipit tempus. Cras at ullamcorper odio.
+  duration: 50 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Resource Manager
 ---
 
 # Lab: Deploying Azure Resource Manager templates


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 3

- `Instructions/Labs/01-exercise-template.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_01_deploying_arm_templates.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_01_deploying_arm_templates.md` (description,duration,level,islab,primarytopics)
