### PR TITLE
Backfill missing lab metadata (3 files)

### DIFF
--- a/Instructions/Labs/01-exercise-template.md
+++ b/Instructions/Labs/01-exercise-template.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Exercise Title'
-    module: 'Learn module title'
+  title: Exercise Title
+  module: Learn module title
+  description: Before you can start this exercise, you will need to...
+  duration: 72 minutes
+  level: 100
+  islab: true
 ---
+
 <!--
 Edit the metadata above to manage the list of exercises in the home page of the GitHub site that gets generated.
 You can delete the module and edit index.md in the root of the repo to customize the display so that only the exercises are listed

--- a/Instructions/Labs/01-exercise-template.md
+++ b/Instructions/Labs/01-exercise-template.md
@@ -1,11 +1,10 @@
 ---
 lab:
-  title: Exercise Title
-  module: Learn module title
-  description: Before you can start this exercise, you will need to...
-  duration: 72 minutes
-  level: 100
-  islab: true
+  title: Exercise title here
+  module: Learn module title here
+  description: Use this lab template to create labs
+  duration: Specify duration in minutes (for example: 30 minutes)
+  level: Use the 100-500 scale. The practitioner level is 300, so most labs will be assigned a level of 200, 300, or 400.
 ---
 
 <!--

--- a/Instructions/Labs/LAB_01_deploying_arm_templates.md
+++ b/Instructions/Labs/LAB_01_deploying_arm_templates.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Lab: Deploying Azure Resource Manager templates'
-    module: 'Module 1: Exploring Azure Resource Manager'
+  title: 'Lab: Deploying Azure Resource Manager templates'
+  module: 'Module 1: Exploring Azure Resource Manager'
+  description: 'After you complete this lab, you will be able to:'
+  duration: 5 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Resource Manager
 ---
 
 # Lab: Deploying Azure Resource Manager templates

--- a/Instructions/Labs/LAB_01_deploying_arm_templates.md
+++ b/Instructions/Labs/LAB_01_deploying_arm_templates.md
@@ -1,14 +1,10 @@
 ---
 lab:
-  title: 'Lab: Deploying Azure Resource Manager templates'
-  module: 'Module 1: Exploring Azure Resource Manager'
-  description: 'After you complete this lab, you will be able to:'
-  duration: 5 minutes
-  level: 200
-  islab: true
-  primarytopics:
-    - Azure
-    - Azure Resource Manager
+  title: Exercise title here
+  module: Learn module title here
+  description: Use this lab template to create labs
+  duration: Specify duration in minutes (for example: 30 minutes)
+  level: Use the 100-500 scale. The practitioner level is 300, so most labs will be assigned a level of 200, 300, or 400.
 ---
 
 # Lab: Deploying Azure Resource Manager templates

--- a/Instructions/Labs/LAB_AK_01_deploying_arm_templates.md
+++ b/Instructions/Labs/LAB_AK_01_deploying_arm_templates.md
@@ -1,15 +1,10 @@
 ---
 lab:
-  title: 'Lab: Deploying Azure Resource Manager templates'
-  type: Answer Key
-  module: 'Module 1: Exploring Azure Resource Manager'
-  description: Maecenas fringilla ac purus non tincidunt. Aenean pellentesque velit id suscipit tempus. Cras at ullamcorper odio.
-  duration: 50 minutes
-  level: 200
-  islab: true
-  primarytopics:
-    - Azure
-    - Azure Resource Manager
+  title: Exercise title here
+  module: Learn module title here
+  description: Use this lab template to create labs
+  duration: Specify duration in minutes (for example: 30 minutes)
+  level: Use the 100-500 scale. The practitioner level is 300, so most labs will be assigned a level of 200, 300, or 400.
 ---
 
 # Lab: Deploying Azure Resource Manager templates

--- a/Instructions/Labs/LAB_AK_01_deploying_arm_templates.md
+++ b/Instructions/Labs/LAB_AK_01_deploying_arm_templates.md
@@ -1,8 +1,15 @@
 ---
 lab:
-    title: 'Lab: Deploying Azure Resource Manager templates'
-    type: 'Answer Key'
-    module: 'Module 1: Exploring Azure Resource Manager'
+  title: 'Lab: Deploying Azure Resource Manager templates'
+  type: Answer Key
+  module: 'Module 1: Exploring Azure Resource Manager'
+  description: Maecenas fringilla ac purus non tincidunt. Aenean pellentesque velit id suscipit tempus. Cras at ullamcorper odio.
+  duration: 50 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Resource Manager
 ---
 
 # Lab: Deploying Azure Resource Manager templates


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 3

- `Instructions/Labs/01-exercise-template.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_01_deploying_arm_templates.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_01_deploying_arm_templates.md` (description,duration,level,islab,primarytopics)
